### PR TITLE
Minor Right Turn Bug

### DIFF
--- a/rules/Complete_Street.cga
+++ b/rules/Complete_Street.cga
@@ -1,7 +1,7 @@
 /*
  * File:    Complete Street.cga
  * Created: 10/30/2015 Oct 2015
- * Last Updated: 5/3/2021
+ * Last Updated: 7/11/2021
  * Author:  David J. Wasserman- As Part of and Based on Work from Esri Redlands
  * License: Apache 2.0 License and ESRI Attribution License.
  * Source: https://github.com/d-wasserman/Complete_Street_Rule
@@ -944,7 +944,7 @@ _stopSten(stopType,lanenumber,lanestotal)			= #TODO: Add more lane options- D.J.
     case stopType == "arrows on side lanes" :
   		_stopListStencil(_dropNones("right;none;none;none;none;none;none;left",lanestotal),lanenumber)
     case stopType == "arrows for right turn":
-  		_stopListStencil(_dropNones("right;right;none",lanestotal),lanenumber)
+  		_stopListStencil(_dropNones("right;right;none;none",lanestotal),lanenumber)
     case stopType == "arrows for left turn" && lanenumber+1==lanestotal :
   		_stopListStencil(_dropNones("none;none;none;none;none;none;none;none;left;left",lanestotal),lanenumber)
     else: #Any time you see more case logic for the first trigger, it is a result of trying to work in the current framework

--- a/rules/Complete_Street_Simple.cga
+++ b/rules/Complete_Street_Simple.cga
@@ -1,7 +1,7 @@
 /*
  * File:    Complete Street.cga
  * Created: 10/30/2015 Oct 2015
- * Last Updated: 5/3/2021
+ * Last Updated: 7/11/2021
  * Author:  David J. Wasserman- As Part of and Based on Work from Esri Redlands
  * License: Apache 2.0 License and ESRI Attribution License.
  * Source: https://github.com/d-wasserman/Complete_Street_Rule
@@ -944,7 +944,7 @@ _stopSten(stopType,lanenumber,lanestotal)			= #TODO: Add more lane options- D.J.
     case stopType == "arrows on side lanes" :
   		_stopListStencil(_dropNones("right;none;none;none;none;none;none;left",lanestotal),lanenumber)
     case stopType == "arrows for right turn":
-  		_stopListStencil(_dropNones("right;right;none",lanestotal),lanenumber)
+  		_stopListStencil(_dropNones("right;right;none;none",lanestotal),lanenumber)
     case stopType == "arrows for left turn" && lanenumber+1==lanestotal :
   		_stopListStencil(_dropNones("none;none;none;none;none;none;none;none;left;left",lanestotal),lanenumber)
     else: #Any time you see more case logic for the first trigger, it is a result of trying to work in the current framework


### PR DESCRIPTION
There was duplicated functionality that works for High LOD right turns, but the "arrows for right turn" option was blanking out. This seems to resolve it for now.